### PR TITLE
Fix for % yoda conditions creating incorrect output

### DIFF
--- a/example.js
+++ b/example.js
@@ -8,7 +8,7 @@ var MapReduce = require('./')
 
 var mapped = MapReduce(db, 'example', function (key, value, emit) {
   console.log('MAP', key, value, '->', Number(value) % 2 ? 'odd' : 'even')
-  if(Number(value) % 2)
+  if(Number(value) % 2 == 0)
     emit('even', Number(value))
   else
     emit('odd', Number(value))


### PR DESCRIPTION
The example was creating the following output 

```
MAP a 1 -> odd
MAP b 2 -> odd
MAP c 3 -> even
MAP d 4 -> even
MAP e 5 -> even
Reduce [ 'odd' ] 3
Reduce [ 'even' ] 12
Reduce [] 3
Reduce [] 15
```

because 2 % Number(value) returns 0 if value <= 2 or 2 if value > 2;

The new output is 

```
MAP a 1 -> odd
MAP d 4 -> even
MAP b 2 -> even
MAP c 3 -> odd
MAP e 5 -> odd
Reduce [ 'even' ] 6
Reduce [ 'odd' ] 9
Reduce [] 6
Reduce [] 15
```
