### PR TITLE
use bytewise for keys

### DIFF
--- a/range.js
+++ b/range.js
@@ -1,43 +1,28 @@
 var bytewise = require('bytewise')
 
-module.exports = function (sep, term, exports) {
+module.exports = function (min, max, exports) {
   exports = exports || {}
 
   exports.parse = function (key) {
-    var array = key.split(sep)
-    var l = +array.shift()
-    if(l == 0)
-      return []
+    var array = bytewise.decode(new Buffer(key, 'hex'))
+    var l = array.shift()
     return array
   }
 
   exports.stringify = function (key) {
-    if('string' === typeof key)
+    if(!Array.isArray(key))
       key = [key]
-    var l = key.length
-
-    return l + sep + key
-    .map(function (e) {
-      if('number' === typeof e)
-        return bytewise.encode(e).toString('hex')
-      return  e
-    })
-    .filter(function (e) {
-      return 'string' === typeof e && e
-    })
-    .join(sep)
-
-   // .map(function (e) { return e + sep } )
+    return bytewise.encode([key.length].concat(key)).toString('hex');
   }
 
   exports.range = function (array) {
     return {
-      min: exports.stringify(array) ,
-      max: exports.stringify(array) + term,
+      min: exports.stringify(array.map(function(v) { if (v === true) return min; else return v})),
+      max: exports.stringify(array.map(function(v) { if (v === true) return max; else return v})),
     }
   }
 
   return exports
 }
 
-module.exports ('!', '~', module.exports)
+module.exports (null, undefined, module.exports)


### PR DESCRIPTION
I think I got it right this time. The important part is generating the right min/max keys for ranges: bytewise encodes so that `null` is always sorted first, and `undefined` is always sorted last, so if `true` is our wildcard value, we just have to replace it with the appropriate value to create the min/max range keys.

Other than that it's just a matter of encoding/decoding the array, with the length prepended/removed to keep grouping levels grouped :)
