### PR TITLE
add createViewStream function

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,10 +112,7 @@ module.exports = function (db, mapDb, map, reduce, initial) {
   mapDb.createViewStream = function(opts) {
     var stream = this.createReadStream(opts)
     stream.on('data', function(d) {
-      stream.emit('row', {
-        key: range.parse(d.key),
-        value: d.value
-      })
+      d.key = range.parse(d.key)
     })
     return stream
   }


### PR DESCRIPTION
When reading map-reduced data from `createReadStream`, the keys that are returned are encoded, and don't correspond to the key that was originally emitted, making them hard to make sense of.

`createViewStream` returns the same stream as `createReadStream`, but emits a `row` event for each `data` event, and decodes the key.

Not sure if this is the "right" way of doing this, but it works. Let me know if there's a better way I should go about this.
