### PR TITLE
Conflicting trigger jobs for multiple map-reduces

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function (db, mapDb, map, reduce, initial) {
     throw new Error('expected a map function')
 
   //when record is inserted, pull out what it was mapped to last time.
-  var maps = Trigger(db, 'maps', function (id, done) {
+  var maps = Trigger(db, 'maps' + Math.random(), function (id, done) {
     mapper.get(id, function (err, oldKeys) {
       oldKeys = oldKeys ? JSON.parse(oldKeys) : []
       var newKeys = []


### PR DESCRIPTION
Trigger jobs are queued in a sublevel named `maps`. However, multiple map-reduces use the same `maps` sublevel which causes unexpected results.  

For example, everytime I restart my db, a full map-reduce is re-triggered on all rows because the trigger jobs queue is never properly cleared.

This is resolved by namespacing the Trigger queues.
